### PR TITLE
Bitstamp Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ typings
 tribeca/
 *.log.*
 test/src
+tribeca.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENV CoinbaseSecret NULL
 ENV CoinbaseOrderDestination Coinbase
 ENV HitBtcOrderDestination HitBtc
 ## Bitstamp - no dev environment
-ENV BitstampPusherUrl ws://ws.pusherapp.com:80/app/de504dc5763aeef9ff52?protocol=6&client=js&version=2.1.2&flash=false
+ENV BitstampPusherUrl ws://ws.pusherapp.com:80/app/de504dc5763aeef9ff52?client=node-pusher-server&version=0.0.1&protocol=5&flash=false
 ENV BitstampHttpUrl https://www.bitstamp.net/api
 ENV BitstampCustomerId NULL
 ENV BitstampApiKey NULL

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,12 @@ ENV CoinbaseApiKey NULL
 ENV CoinbaseSecret NULL
 ENV CoinbaseOrderDestination Coinbase
 ENV HitBtcOrderDestination HitBtc
+## Bitstamp - no dev environment
+ENV BitstampPusherUrl ws://ws.pusherapp.com:80/app/de504dc5763aeef9ff52?protocol=6&client=js&version=2.1.2&flash=false
+ENV BitstampHttpUrl https://www.bitstamp.net/api
+ENV BitstampCustomerId NULL
+ENV BitstampApiKey NULL
+ENV BitstampSecret NULL
 
 # PROD - values provided for reference.
 ## HitBtc

--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@
 
   * EXCHANGE
   
-    1) `coinbase` - uses the WebSocket API. Ensure the Coinbase-specific properties have been set with your correct account information if you are using the sandbox or live-trading environment.
+    1) `coinbase` - uses the WebSocket market data API and REST order API. Ensure the Coinbase-specific properties have been set with your correct account information if you are using the sandbox or live-trading environment.
     
     2) `hitbtc` - WebSocket + socket.io API. Ensure the HitBtc-specific properties have been set with your correct account information if you are using the dev or prod environment.
     
-    3) `null` - Test in-memory exchange. No exchange-specific config needed.
+    3) `okcoin` - Websocket. Ensure the OKCoin-specific properties have been set with your correct account information. Production environment only.
+    
+    4) `bitstamp` - Websocket market data and REST order API. Ensure the Bitstamp-specific properties have been set with your correct account information. Production environment only.
+    
+    5) `null` - Test in-memory exchange. No exchange-specific config needed.
     
   * TRIBECA_MODE
   

--- a/sample-dev-tribeca.json
+++ b/sample-dev-tribeca.json
@@ -18,9 +18,9 @@
     "CoinbaseApiKey": "NULL",
     "CoinbaseSecret": "NULL",
     
-    "BitstampPusherUrl": "ws://ws.pusherapp.com:80/app/de504dc5763aeef9ff52?protocol=6&client=js&version=2.1.2&flash=false",
+    "BitstampPusherUrl": "ws://ws.pusherapp.com:80/app/de504dc5763aeef9ff52?client=node-pusher-server&version=0.0.1&protocol=5&flash=false",
     "BitstampHttpUrl": "https://www.bitstamp.net/api",
     "BitstampCustomerId": "NULL",
     "BitstampApiKey": "NULL",
-    "BitstampSecret": "NULL",
+    "BitstampSecret": "NULL"
 }

--- a/sample-dev-tribeca.json
+++ b/sample-dev-tribeca.json
@@ -17,6 +17,13 @@
     "CoinbasePassphrase": "NULL",
     "CoinbaseApiKey": "NULL",
     "CoinbaseSecret": "NULL",
+    
+    "BitstampPusherUrl": "ws://ws.pusherapp.com:80/app/de504dc5763aeef9ff52?protocol=6&client=js&version=2.1.2&flash=false",
+    "BitstampHttpUrl": "https://www.bitstamp.net/api",
+    "BitstampCustomerId": "NULL",
+    "BitstampApiKey": "NULL",
+    "BitstampSecret": "NULL",
+    
     "CoinbaseOrderDestination": "Coinbase",
     "HitBtcOrderDestination": "HitBtc"
 }

--- a/sample-dev-tribeca.json
+++ b/sample-dev-tribeca.json
@@ -23,7 +23,4 @@
     "BitstampCustomerId": "NULL",
     "BitstampApiKey": "NULL",
     "BitstampSecret": "NULL",
-    
-    "CoinbaseOrderDestination": "Coinbase",
-    "HitBtcOrderDestination": "HitBtc"
 }

--- a/sample-dev-tribeca.json
+++ b/sample-dev-tribeca.json
@@ -16,20 +16,17 @@
     "CoinbasePassphrase": "NULL",
     "CoinbaseApiKey": "NULL",
     "CoinbaseSecret": "NULL",
-<<<<<<< HEAD
+    "CoinbaseOrderDestination": "Coinbase",
     
     "BitstampPusherUrl": "ws://ws.pusherapp.com:80/app/de504dc5763aeef9ff52?client=node-pusher-server&version=0.0.1&protocol=5&flash=false",
     "BitstampHttpUrl": "https://www.bitstamp.net/api",
     "BitstampCustomerId": "NULL",
     "BitstampApiKey": "NULL",
     "BitstampSecret": "NULL"
-=======
-    "CoinbaseOrderDestination": "Coinbase",
     
     "OkCoinWsUrl": "wss://real.okcoin.com:10440/websocket/okcoinapi",
     "OkCoinHttpUrl": "https://www.okcoin.com/api/v1/",
     "OkCoinApiKey": "NULL",
     "OkCoinSecretKey": "NULL",
     "OkCoinOrderDestination": "OkCoin"
->>>>>>> master
 }

--- a/sample-prod-tribeca.json
+++ b/sample-prod-tribeca.json
@@ -18,7 +18,7 @@
     "CoinbaseApiKey": "NULL",
     "CoinbaseSecret": "NULL",
     
-    "BitstampPusherUrl": "ws://ws.pusherapp.com:80/app/de504dc5763aeef9ff52?protocol=6&client=js&version=2.1.2&flash=false",
+    "BitstampPusherUrl": "ws://ws.pusherapp.com:80/app/de504dc5763aeef9ff52?client=node-pusher-server&version=0.0.1&protocol=5&flash=false",
     "BitstampHttpUrl": "https://www.bitstamp.net/api",
     "BitstampCustomerId": "NULL",
     "BitstampApiKey": "NULL",

--- a/sample-prod-tribeca.json
+++ b/sample-prod-tribeca.json
@@ -22,8 +22,5 @@
     "BitstampHttpUrl": "https://www.bitstamp.net/api",
     "BitstampCustomerId": "NULL",
     "BitstampApiKey": "NULL",
-    "BitstampSecret": "NULL",
-    
-    "CoinbaseOrderDestination": "Coinbase",
-    "HitBtcOrderDestination": "HitBtc"
+    "BitstampSecret": "NULL"
 }

--- a/sample-prod-tribeca.json
+++ b/sample-prod-tribeca.json
@@ -17,6 +17,13 @@
     "CoinbasePassphrase": "NULL",
     "CoinbaseApiKey": "NULL",
     "CoinbaseSecret": "NULL",
+    
+    "BitstampPusherUrl": "ws://ws.pusherapp.com:80/app/de504dc5763aeef9ff52?protocol=6&client=js&version=2.1.2&flash=false",
+    "BitstampHttpUrl": "https://www.bitstamp.net/api",
+    "BitstampCustomerId": "NULL",
+    "BitstampApiKey": "NULL",
+    "BitstampSecret": "NULL",
+    
     "CoinbaseOrderDestination": "Coinbase",
     "HitBtcOrderDestination": "HitBtc"
 }

--- a/sample-prod-tribeca.json
+++ b/sample-prod-tribeca.json
@@ -16,20 +16,17 @@
     "CoinbasePassphrase": "NULL",
     "CoinbaseApiKey": "NULL",
     "CoinbaseSecret": "NULL",
-<<<<<<< HEAD
+    "CoinbaseOrderDestination": "Coinbase",
     
     "BitstampPusherUrl": "ws://ws.pusherapp.com:80/app/de504dc5763aeef9ff52?client=node-pusher-server&version=0.0.1&protocol=5&flash=false",
     "BitstampHttpUrl": "https://www.bitstamp.net/api",
     "BitstampCustomerId": "NULL",
     "BitstampApiKey": "NULL",
     "BitstampSecret": "NULL"
-=======
-    "CoinbaseOrderDestination": "Coinbase",
     
     "OkCoinWsUrl": "wss://real.okcoin.com:10440/websocket/okcoinapi",
     "OkCoinHttpUrl": "https://www.okcoin.com/api/v1/",
     "OkCoinApiKey": "NULL",
     "OkCoinSecretKey": "NULL",
     "OkCoinOrderDestination": "OkCoin"
->>>>>>> master
 }

--- a/src/common/models.ts
+++ b/src/common/models.ts
@@ -59,7 +59,7 @@ export class MarketTrade implements ITimestamped {
 export enum GatewayType { MarketData, OrderEntry, Position }
 export enum Currency { USD, BTC, LTC }
 export enum ConnectivityStatus { Connected, Disconnected }
-export enum Exchange { Null, HitBtc, OkCoin, AtlasAts, BtcChina, Coinbase }
+export enum Exchange { Null, HitBtc, OkCoin, AtlasAts, BtcChina, Coinbase, Bitstamp }
 export enum Side { Bid, Ask }
 export enum OrderType { Limit, Market }
 export enum TimeInForce { IOC, FOK, GTC }

--- a/src/service/gateways/bitstamp.ts
+++ b/src/service/gateways/bitstamp.ts
@@ -1,0 +1,203 @@
+/// <reference path="../../../typings/tsd.d.ts" />
+/// <reference path="../utils.ts" />
+/// <reference path="../../common/models.ts" />
+/// <reference path="nullgw.ts" />
+
+import Config = require("../config");
+import crypto = require('crypto');
+import ws = require('ws');
+import request = require('request');
+import Models = require("../../common/models");
+import Utils = require("../utils");
+import Interfaces = require("../interfaces");
+import moment = require("moment");
+import util = require("util");
+import _ = require('lodash');
+
+class OrderBook {
+	bids : [number, number][];
+	asks : [number, number][];
+}
+
+class Ticker {
+	id : string;
+	amount : number;
+	price : number;
+}
+
+class PusherClient<T> {
+	private _ws;
+	private _log : Utils.Logger;
+	
+	ConnectionState : Models.ConnectivityStatus = Models.ConnectivityStatus.Disconnected;
+	ConnectChanged = new Utils.Evt<Models.ConnectivityStatus>();
+	private onConnectionStatusChange = () => {
+        if (this._ws.readyState === WebSocket.OPEN) {
+            this.ConnectChanged.trigger(Models.ConnectivityStatus.Connected);
+			this.ConnectionState = Models.ConnectivityStatus.Connected;
+        }
+        else {
+            this.ConnectChanged.trigger(Models.ConnectivityStatus.Disconnected);
+			this.ConnectionState = Models.ConnectivityStatus.Disconnected;
+        }
+    };
+	
+	Message = new Utils.Evt<Models.Timestamped<T>>();
+	private onMessage = (data) => {
+		try {
+			var first = JSON.parse(data);
+			
+			if (!first.hasOwnProperty("data"))
+				return;
+			
+			var t = Utils.date();
+			this.Message.trigger(new Models.Timestamped(JSON.parse(first['data']), t));
+		} catch (error) {
+			this._log("Error parsing data", data, error);
+		}
+	};
+	
+	constructor(url: string, endpoint: string) {
+		this._log = Utils.log("tribeca:gateway:"+endpoint);
+		this._ws = new WebSocket(url);
+		
+		this._ws.on('open', () => {
+			this.onConnectionStatusChange();
+			
+			this._ws.send(JSON.stringify({'data': {'channel': endpoint}, 'event': 'pusher:subscribe'}));
+		});
+        this._ws.on('message', this.onMessage);
+        this._ws.on("close", (code, msg) => {
+            this.onConnectionStatusChange();
+            this._log("close code=%d msg=%s", code, msg);
+        });
+        this._ws.on("error", err => {
+            this.onConnectionStatusChange();
+            this._log("error %s", err);
+            throw err;
+        });
+	}
+}
+
+class BitstampMarketDataGateway implements Interfaces.IMarketDataGateway {
+    MarketData = new Utils.Evt<Models.Market>();
+    MarketTrade = new Utils.Evt<Models.GatewayMarketTrade>();
+	
+	private _orderBookClient : PusherClient<OrderBook>;
+	private _tickerWsClient : PusherClient<Ticker>;
+	
+	ConnectChanged = new Utils.Evt<Models.ConnectivityStatus>();
+	private onConnectChanged = () => {
+		if (this._orderBookClient.ConnectionState === Models.ConnectivityStatus.Connected 
+				&& this._tickerWsClient.ConnectionState === Models.ConnectivityStatus.Connected) {
+			this.ConnectChanged.trigger(Models.ConnectivityStatus.Connected);
+		}
+		else {
+			this.ConnectChanged.trigger(Models.ConnectivityStatus.Disconnected);
+		}
+	};
+	
+	private static ConvertToMarketSide = (input : [number, number]) => new Models.MarketSide(input[0], input[1]);
+	private onOrderBookMessage = (message : Models.Timestamped<OrderBook>) => {
+		var bids = message.data.bids.map(BitstampMarketDataGateway.ConvertToMarketSide);
+        var asks = message.data.asks.map(BitstampMarketDataGateway.ConvertToMarketSide);
+		this.MarketData.trigger(new Models.Market(bids, asks, message.time));
+	};
+    
+    private onTicker = (message : Models.Timestamped<Ticker>) => {
+        var trd = new Models.GatewayMarketTrade(message.data.price, message.data.amount,  message.time, false, null);
+        this.MarketTrade.trigger(trd);
+    };
+	
+     _log : Utils.Logger = Utils.log("tribeca:gateway:BitstampMD");
+    constructor(config : Config.IConfigProvider) {
+		var url = config.GetString("BitstampPusherUrl");
+		this._orderBookClient = new PusherClient(url, "order_book");
+		this._orderBookClient.ConnectChanged.on(this.onConnectChanged);
+		this._orderBookClient.Message.on(this.onOrderBookMessage);
+		
+		this._tickerWsClient = new PusherClient(url, "live_trades");
+		this._tickerWsClient.ConnectChanged.on(this.onConnectChanged);
+        this._tickerWsClient.Message.on(this.onTicker);
+    }
+}
+
+class BitstampEntryGateway implements Interfaces.IOrderEntryGateway {
+    OrderUpdate = new Utils.Evt<Models.OrderStatusReport>();
+    ConnectChanged = new Utils.Evt<Models.ConnectivityStatus>();
+    
+    public cancelsByClientOrderId = false;
+
+    private _nonce; // strictly monotonic -- use unix time
+
+    cancelOrder = (cancel : Models.BrokeredCancel) : Models.OrderGatewayActionReport => {
+        // send cancel
+        return new Models.OrderGatewayActionReport(Utils.date());
+    };
+
+    replaceOrder = (replace : Models.BrokeredReplace) : Models.OrderGatewayActionReport => {
+        this.cancelOrder(new Models.BrokeredCancel(replace.origOrderId, replace.orderId, replace.side, replace.exchangeId));
+        return this.sendOrder(replace);
+    };
+
+    sendOrder = (order : Models.BrokeredOrder) : Models.OrderGatewayActionReport => {
+        // send order
+        return new Models.OrderGatewayActionReport(Utils.date());
+    };
+    
+    generateClientOrderId = () : string => { 
+        return "something";
+    };
+
+    // handle order status
+
+     _log : Utils.Logger = Utils.log("tribeca:gateway:BitstampOE");
+    
+    constructor(config : Config.IConfigProvider) {
+        
+    }
+}
+
+class BitstampPositionGateway implements Interfaces.IPositionGateway {
+    _log : Utils.Logger = Utils.log("tribeca:gateway:BitstampPG");
+    PositionUpdate = new Utils.Evt<Models.CurrencyPosition>();
+
+    constructor(config : Config.IConfigProvider) {
+        
+    }
+}
+
+class BitstampBaseGateway implements Interfaces.IExchangeDetailsGateway {
+    public get hasSelfTradePrevention() {
+        return false;
+    }
+
+    exchange() : Models.Exchange {
+        return Models.Exchange.Bitstamp;
+    }
+
+    makeFee() : number {
+        return 0.0025;
+    }
+
+    takeFee() : number {
+        return 0.0025;
+    }
+
+    name() : string {
+        return "Bitstamp";
+    }
+}
+
+export class Bitstamp extends Interfaces.CombinedGateway {
+    constructor(config : Config.IConfigProvider) {
+        var orderGateway = new BitstampEntryGateway(config);
+        var positionGateway = new BitstampPositionGateway(config);
+        var marketDataGateway = new BitstampMarketDataGateway(config);
+        super(
+            marketDataGateway,
+            orderGateway,
+            positionGateway,
+            new BitstampBaseGateway());
+    }
+}

--- a/src/service/main.ts
+++ b/src/service/main.ts
@@ -14,6 +14,7 @@ import request = require('request');
 
 import HitBtc = require("./gateways/hitbtc");
 import Coinbase = require("./gateways/coinbase");
+import Bitstamp = require("./gateways/bitstamp");
 import NullGw = require("./gateways/nullgw");
 
 import Utils = require("./utils");
@@ -115,6 +116,7 @@ var liveTradingSetup = () => {
         switch (ex) {
             case "hitbtc": return Models.Exchange.HitBtc;
             case "coinbase": return Models.Exchange.Coinbase;
+            case "bitstamp": return Models.Exchange.Bitstamp;
             case "null": return Models.Exchange.Null;
             default: throw new Error("unknown configuration env variable EXCHANGE " + ex);
         }
@@ -126,6 +128,7 @@ var liveTradingSetup = () => {
         switch (exchange) {
             case Models.Exchange.HitBtc: return <Interfaces.CombinedGateway>(new HitBtc.HitBtc(config));
             case Models.Exchange.Coinbase: return <Interfaces.CombinedGateway>(new Coinbase.Coinbase(config, orderCache, timeProvider));
+            case Models.Exchange.Bitstamp: return <Interfaces.CombinedGateway>(new Bitstamp.Bitstamp(timeProvider, config));
             case Models.Exchange.Null: return <Interfaces.CombinedGateway>(new NullGw.NullGateway());
             default: throw new Error("no gateway provided for exchange " + exchange);
         }


### PR DESCRIPTION
This is a partially completed implementation of the Bitstamp API for tribeca. I don't have a Bitstamp account, and I don't want to provide them with all the legal documents (https://www.bitstamp.net/account/verify/) for API access, so the authorized methods (buy, sell, account information, order status) are not tested. There is new config variables for Bitstamp and an Exchange enum value for Bitstamp now.

The market data API handling works just fine.

I'm leaving this pull request open until someone has the ability to implement the missing functionality and willing to test their implementation. I'm going to write some notes where I'm unsure of functionality.