### PR TITLE
Added support for BTC/EUR and BTC/GBP on exchanges which support those

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ EXPOSE 3000 5000
 # General config properties. Properties with `NULL` should be replaced with your own exchange account information.
 ENV TRIBECA_MODE dev
 ENV EXCHANGE null
+ENV TradedPair BTC/USD
 # IP to access mongo instance. If you are on a mac, run `boot2docker ip` and replace `tribeca-mongo`.
 ENV MongoDbUrl mongodb://tribeca-mongo:27017/tribeca
 ENV CoinbaseOrderDestination Coinbase

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@
     2) `dev`
     
   * MongoDbUrl - If you are on OS X, change "tribeca-mongo" in the URL to the output of `boot2docker ip` on your host machine. If you are running an existing mongoDB instance, replace the URL with the existing instance's URL. If you are running from a Linux machine and set up mongo in step 1, you should not have to modify anything.
+  
+  * TradedPair - The following currency pairs are supported on these exchanges:
+  
+    1) `BTC/USD` - Coinbase, HitBtc, OkCoin, Null
+    
+    2) `BTC/EUR` - Coinbase, HitBtc, Null
+    
+    3) `BTC/GBP` - Coinbase, Null
 
 3) Save the Dockerfile, preferably in a secure location and in an empty directory. Build the image from the Dockerfile `docker build -t tribeca .`
 

--- a/sample-dev-tribeca.json
+++ b/sample-dev-tribeca.json
@@ -1,6 +1,7 @@
 {
     "TRIBECA_MODE": "dev",
     "EXCHANGE": "null",
+    "TradedPair": "BTC/USD",
     "MongoDbUrl": "mongodb://localhost:27017/tribeca",
     
     "HitBtcPullUrl": "http://demo-api.hitbtc.com",

--- a/sample-prod-tribeca.json
+++ b/sample-prod-tribeca.json
@@ -1,6 +1,7 @@
 {
     "TRIBECA_MODE": "prod",
     "EXCHANGE": "null",
+    "TradedPair": "BTC/USD",
     "MongoDbUrl": "mongodb://localhost:27017/tribeca",
     
     "HitBtcPullUrl": "http://api.hitbtc.com",

--- a/src/common/models.ts
+++ b/src/common/models.ts
@@ -57,7 +57,7 @@ export class MarketTrade implements ITimestamped {
 }
 
 export enum GatewayType { MarketData, OrderEntry, Position }
-export enum Currency { USD, BTC, LTC }
+export enum Currency { USD, BTC, LTC, EUR, GBP, CNY }
 export enum ConnectivityStatus { Connected, Disconnected }
 export enum Exchange { Null, HitBtc, OkCoin, AtlasAts, BtcChina, Coinbase }
 export enum Side { Bid, Ask }

--- a/src/service/backtest.ts
+++ b/src/service/backtest.ts
@@ -260,6 +260,13 @@ class BacktestGatewayDetails implements Interfaces.IExchangeDetailsGateway {
     exchange(): Models.Exchange {
         return Models.Exchange.Null;
     }
+    
+    private static AllPairs = [
+        new Models.CurrencyPair(Models.Currency.BTC, Models.Currency.USD)
+    ];
+    public get supportedCurrencyPairs() {
+        return BacktestGatewayDetails.AllPairs;
+    }
 }
 
 export class BacktestParameters {

--- a/src/service/broker.ts
+++ b/src/service/broker.ts
@@ -421,6 +421,10 @@ export class ExchangeBroker implements Interfaces.IBroker {
     public get pair() {
         return this._pair;
     }
+    
+    public get supportedCurrencyPairs() : Models.CurrencyPair[] {
+        return this._baseGateway.supportedCurrencyPairs;
+    }
 
     ConnectChanged = new Utils.Evt<Models.ConnectivityStatus>();
     private mdConnected = Models.ConnectivityStatus.Disconnected;

--- a/src/service/gateways/coinbase-api.ts
+++ b/src/service/gateways/coinbase-api.ts
@@ -397,7 +397,7 @@ _.assign(OrderBook.prototype, new function() {
         };
 
         request({
-            'url': self.restURI + '/products/BTC-USD/book?level=3',
+            'url': self.restURI + '/products/' + self.productID + '/book?level=3',
             'headers': { 'User-Agent': 'coinbase-node-client' },
         }, function(err, response, body) {
                 if (err) {

--- a/src/service/gateways/coinbase.ts
+++ b/src/service/gateways/coinbase.ts
@@ -737,6 +737,34 @@ class CoinbaseBaseGateway implements Interfaces.IExchangeDetailsGateway {
     }
 }
 
+function GetCurrencyEnum(c: string) : Models.Currency {
+    switch (name.toLowerCase()) {
+        case "BTC": return Models.Currency.BTC;
+        case "USD": return Models.Currency.USD;
+        case "EUR": return Models.Currency.EUR;
+        case "GBP": return Models.Currency.GBP;
+        default: throw new Error("Unsupported currency " + name);
+    }
+}
+
+function GetCurrencySymbol(c: Models.Currency) : string {
+    switch (c) {
+        case Models.Currency.USD: return "USD";
+        case Models.Currency.GBP: return "GBP";
+        case Models.Currency.BTC: return "BTC";
+        case Models.Currency.EUR: return "EUR";
+        default: throw new Error("Unsupported currency " + Models.Currency[c]);
+    }
+}
+
+class CoinbaseSymbolProvider {
+    public symbol : string;
+    
+    constructor(pair: Models.CurrencyPair) {
+        this.symbol = GetCurrencySymbol(pair.base) + "-" + GetCurrencySymbol(pair.quote);
+    }
+}
+
 export class Coinbase extends Interfaces.CombinedGateway {
     constructor(config: Config.IConfigProvider, orders: Interfaces.IOrderStateCache, timeProvider: Utils.ITimeProvider) {
         var orderEventEmitter = new CoinbaseExchange.OrderBook("BTC-USD", config.GetString("CoinbaseWebsocketUrl"), config.GetString("CoinbaseRestUrl"), timeProvider);

--- a/src/service/gateways/coinbase.ts
+++ b/src/service/gateways/coinbase.ts
@@ -766,7 +766,9 @@ class CoinbaseSymbolProvider {
 }
 
 export class Coinbase extends Interfaces.CombinedGateway {
-    constructor(config: Config.IConfigProvider, orders: Interfaces.IOrderStateCache, timeProvider: Utils.ITimeProvider) {
+    constructor(config: Config.IConfigProvider, orders: Interfaces.IOrderStateCache, timeProvider: Utils.ITimeProvider, pair: Models.CurrencyPair) {
+        var symbolProvider = new CoinbaseSymbolProvider(pair);
+        
         var orderEventEmitter = new CoinbaseExchange.OrderBook("BTC-USD", config.GetString("CoinbaseWebsocketUrl"), config.GetString("CoinbaseRestUrl"), timeProvider);
         var authClient = new CoinbaseExchange.AuthenticatedClient(config.GetString("CoinbaseApiKey"),
             config.GetString("CoinbaseSecret"), config.GetString("CoinbasePassphrase"), config.GetString("CoinbaseRestUrl"));

--- a/src/service/gateways/coinbase.ts
+++ b/src/service/gateways/coinbase.ts
@@ -726,6 +726,15 @@ class CoinbaseBaseGateway implements Interfaces.IExchangeDetailsGateway {
     name(): string {
         return "Coinbase";
     }
+    
+    private static AllPairs = [
+        new Models.CurrencyPair(Models.Currency.BTC, Models.Currency.USD),
+        new Models.CurrencyPair(Models.Currency.BTC, Models.Currency.EUR),
+        new Models.CurrencyPair(Models.Currency.BTC, Models.Currency.GBP)
+    ];
+    public get supportedCurrencyPairs() {
+        return CoinbaseBaseGateway.AllPairs;
+    }
 }
 
 export class Coinbase extends Interfaces.CombinedGateway {

--- a/src/service/gateways/hitbtc.ts
+++ b/src/service/gateways/hitbtc.ts
@@ -606,7 +606,8 @@ class HitBtcSymbolProvider {
 }
 
 export class HitBtc extends Interfaces.CombinedGateway {
-    constructor(config : Config.IConfigProvider) {
+    constructor(config : Config.IConfigProvider, pair: Models.CurrencyPair) {
+        var symbolProvider = new HitBtcSymbolProvider(pair);
         var orderGateway = config.GetString("HitBtcOrderDestination") == "HitBtc" ?
             <Interfaces.IOrderEntryGateway>new HitBtcOrderEntryGateway(config)
             : new NullGateway.NullOrderGateway();

--- a/src/service/gateways/hitbtc.ts
+++ b/src/service/gateways/hitbtc.ts
@@ -558,6 +558,23 @@ class HitBtcBaseGateway implements Interfaces.IExchangeDetailsGateway {
     name() : string {
         return "HitBtc";
     }
+    
+    private static AllPairs = [
+        new Models.CurrencyPair(Models.Currency.BTC, Models.Currency.USD),
+        new Models.CurrencyPair(Models.Currency.BTC, Models.Currency.EUR),
+        
+        // don't use these yet.
+        //new Models.CurrencyPair(Models.Currency.LTC, Models.Currency.BTC),
+        //new Models.CurrencyPair(Models.Currency.LTC, Models.Currency.USD),
+        //new Models.CurrencyPair(Models.Currency.LTC, Models.Currency.EUR),
+        //new Models.CurrencyPair(Models.Currency.DOGE, Models.Currency.BTC),
+        //new Models.CurrencyPair(Models.Currency.XMR, Models.Currency.BTC),
+        //new Models.CurrencyPair(Models.Currency.BCN, Models.Currency.BTC),
+        //new Models.CurrencyPair(Models.Currency.XDN, Models.Currency.BTC),
+    ];
+    public get supportedCurrencyPairs() {
+        return HitBtcBaseGateway.AllPairs;
+    }
 }
 
 export class HitBtc extends Interfaces.CombinedGateway {

--- a/src/service/gateways/hitbtc.ts
+++ b/src/service/gateways/hitbtc.ts
@@ -577,6 +577,34 @@ class HitBtcBaseGateway implements Interfaces.IExchangeDetailsGateway {
     }
 }
 
+function GetCurrencyEnum(c: string) : Models.Currency {
+    switch (name.toLowerCase()) {
+        case "BTC": return Models.Currency.BTC;
+        case "USD": return Models.Currency.USD;
+        case "EUR": return Models.Currency.EUR;
+        case "LTC": return Models.Currency.LTC;
+        default: throw new Error("Unsupported currency " + name);
+    }
+}
+
+function GetCurrencySymbol(c: Models.Currency) : string {
+    switch (c) {
+        case Models.Currency.USD: return "USD";
+        case Models.Currency.LTC: return "LTC";
+        case Models.Currency.BTC: return "BTC";
+        case Models.Currency.EUR: return "EUR";
+        default: throw new Error("Unsupported currency " + Models.Currency[c]);
+    }
+}
+
+class HitBtcSymbolProvider {
+    public symbol : string;
+    
+    constructor(pair: Models.CurrencyPair) {
+        this.symbol = GetCurrencySymbol(pair.base) + GetCurrencySymbol(pair.quote);
+    }
+}
+
 export class HitBtc extends Interfaces.CombinedGateway {
     constructor(config : Config.IConfigProvider) {
         var orderGateway = config.GetString("HitBtcOrderDestination") == "HitBtc" ?

--- a/src/service/gateways/hitbtc.ts
+++ b/src/service/gateways/hitbtc.ts
@@ -491,15 +491,6 @@ class HitBtcPositionGateway implements Interfaces.IPositionGateway {
                 qs: {nonce: nonce.toString(), apikey: this._apiKey}};
     };
 
-    private static convertCurrency(code : string) : Models.Currency {
-        switch (code) {
-            case "USD": return Models.Currency.USD;
-            case "BTC": return Models.Currency.BTC;
-            case "LTC": return Models.Currency.LTC;
-            default: return null;
-        }
-    }
-
     private onTick = () => {
         request.get(
             this.getAuth("/api/1/trading/balance"),
@@ -513,7 +504,7 @@ class HitBtcPositionGateway implements Interfaces.IPositionGateway {
                     }
 
                     rpts.forEach(r => {
-                        var currency = HitBtcPositionGateway.convertCurrency(r.currency_code);
+                        var currency = GetCurrencyEnum(r.currency_code);
                         if (currency == null) return;
                         var position = new Models.CurrencyPosition(r.cash, r.reserved, currency);
                         this.PositionUpdate.trigger(position);

--- a/src/service/gateways/nullgw.ts
+++ b/src/service/gateways/nullgw.ts
@@ -61,6 +61,8 @@ export class NullPositionGateway implements Interfaces.IPositionGateway {
 
     constructor() {
         setInterval(() => this.PositionUpdate.trigger(new Models.CurrencyPosition(500, 50, Models.Currency.USD)), 2500);
+        setInterval(() => this.PositionUpdate.trigger(new Models.CurrencyPosition(500, 50, Models.Currency.EUR)), 2500);
+        setInterval(() => this.PositionUpdate.trigger(new Models.CurrencyPosition(500, 50, Models.Currency.GBP)), 2500);
         setInterval(() => this.PositionUpdate.trigger(new Models.CurrencyPosition(2, .5, Models.Currency.BTC)), 5000);
     }
 }
@@ -116,7 +118,9 @@ class NullGatewayDetails implements Interfaces.IExchangeDetailsGateway {
     }
     
     private static AllPairs = [
-        new Models.CurrencyPair(Models.Currency.BTC, Models.Currency.USD)
+        new Models.CurrencyPair(Models.Currency.BTC, Models.Currency.USD),
+        new Models.CurrencyPair(Models.Currency.BTC, Models.Currency.EUR),
+        new Models.CurrencyPair(Models.Currency.BTC, Models.Currency.GBP)
     ];
     public get supportedCurrencyPairs() {
         return NullGatewayDetails.AllPairs;

--- a/src/service/gateways/nullgw.ts
+++ b/src/service/gateways/nullgw.ts
@@ -114,6 +114,13 @@ class NullGatewayDetails implements Interfaces.IExchangeDetailsGateway {
     exchange(): Models.Exchange {
         return Models.Exchange.Null;
     }
+    
+    private static AllPairs = [
+        new Models.CurrencyPair(Models.Currency.BTC, Models.Currency.USD)
+    ];
+    public get supportedCurrencyPairs() {
+        return NullGatewayDetails.AllPairs;
+    }
 }
 
 export class NullGateway extends Interfaces.CombinedGateway {

--- a/src/service/gateways/okcoin.ts
+++ b/src/service/gateways/okcoin.ts
@@ -164,16 +164,19 @@ class OkCoinMarketDataGateway implements Interfaces.IMarketDataGateway {
     };
 
     private _log : Utils.Logger = Utils.log("tribeca:gateway:OkCoinMD");
-    constructor(socket : OkCoinWebsocket) {
-        socket.setHandler("ok_btcusd_depth", this.onDepth);
-        socket.setHandler("ok_btcusd_trades_v1", this.onTrade);
+    constructor(socket : OkCoinWebsocket, symbolProvider: OkCoinSymbolProvider) {
+        var depthChannel = "ok_" + symbolProvider.symbol + "_depth";
+        var tradesChannel = "ok_" + symbolProvider.symbol + "_trades_v1";
+        
+        socket.setHandler(depthChannel, this.onDepth);
+        socket.setHandler(tradesChannel, this.onTrade);
         
         socket.ConnectChanged.on(cs => {
             this.ConnectChanged.trigger(cs);
             
             if (cs == Models.ConnectivityStatus.Connected) {
-                socket.send("ok_btcusd_depth", {});
-                socket.send("ok_btcusd_trades_v1", {});
+                socket.send(depthChannel, {});
+                socket.send(tradesChannel, {});
             }
         });
     }
@@ -205,7 +208,7 @@ class OkCoinOrderEntryGateway implements Interfaces.IOrderEntryGateway {
 
     sendOrder = (order : Models.BrokeredOrder) : Models.OrderGatewayActionReport => {
         var o : Order = {
-            symbol: "btc_usd", //btc_usd: bitcoin ltc_usd: litecoin,
+            symbol: this._symbolProvider.symbol,
             type: OkCoinOrderEntryGateway.GetOrderType(order.side, order.type),
             price: order.price.toString(),
             amount: order.quantity.toString()};
@@ -237,7 +240,7 @@ class OkCoinOrderEntryGateway implements Interfaces.IOrderEntryGateway {
     };
 
     cancelOrder = (cancel : Models.BrokeredCancel) : Models.OrderGatewayActionReport => {
-        var c : Cancel = {order_id: cancel.exchangeId, symbol: "btc_usd" };
+        var c : Cancel = {order_id: cancel.exchangeId, symbol: this._symbolProvider.symbol };
         this._socket.send<OrderAck>("ok_spotusd_cancel_order", this._signer.signMessage(c));
         return new Models.OrderGatewayActionReport(Utils.date());
     };
@@ -296,7 +299,10 @@ class OkCoinOrderEntryGateway implements Interfaces.IOrderEntryGateway {
     };
 
     private _log : Utils.Logger = Utils.log("tribeca:gateway:OkCoinOE");
-    constructor(private _socket : OkCoinWebsocket, private _signer: OkCoinMessageSigner) {
+    constructor(
+            private _socket : OkCoinWebsocket, 
+            private _signer: OkCoinMessageSigner,
+            private _symbolProvider: OkCoinSymbolProvider) {
         _socket.setHandler("ok_usd_realtrades", this.onTrade);
         _socket.setHandler("ok_spotusd_trade", this.onOrderAck);
         _socket.setHandler("ok_spotusd_cancel_order", this.onCancel);
@@ -478,11 +484,11 @@ export class OkCoin extends Interfaces.CombinedGateway {
         var socket = new OkCoinWebsocket(config);
 
         var orderGateway = config.GetString("OkCoinOrderDestination") == "OkCoin"
-            ? <Interfaces.IOrderEntryGateway>new OkCoinOrderEntryGateway(socket, signer)
+            ? <Interfaces.IOrderEntryGateway>new OkCoinOrderEntryGateway(socket, signer, symbol)
             : new NullGateway.NullOrderGateway();
 
         super(
-            new OkCoinMarketDataGateway(socket),
+            new OkCoinMarketDataGateway(socket, symbol),
             orderGateway,
             new OkCoinPositionGateway(http),
             new OkCoinBaseGateway());

--- a/src/service/gateways/okcoin.ts
+++ b/src/service/gateways/okcoin.ts
@@ -434,6 +434,14 @@ class OkCoinBaseGateway implements Interfaces.IExchangeDetailsGateway {
     exchange() : Models.Exchange {
         return Models.Exchange.OkCoin;
     }
+    
+    private static AllPairs = [
+        new Models.CurrencyPair(Models.Currency.BTC, Models.Currency.USD),
+        //new Models.CurrencyPair(Models.Currency.LTC, Models.Currency.USD),
+    ];
+    public get supportedCurrencyPairs() {
+        return OkCoinBaseGateway.AllPairs;
+    }
 }
 
 export class OkCoin extends Interfaces.CombinedGateway {

--- a/src/service/gateways/okcoin.ts
+++ b/src/service/gateways/okcoin.ts
@@ -444,6 +444,32 @@ class OkCoinBaseGateway implements Interfaces.IExchangeDetailsGateway {
     }
 }
 
+function GetCurrencyEnum(c: string) : Models.Currency {
+    switch (name.toLowerCase()) {
+        case "usd": return Models.Currency.USD;
+        case "ltc": return Models.Currency.LTC;
+        case "btc": return Models.Currency.BTC;
+        default: throw new Error("Unsupported currency " + name);
+    }
+}
+
+function GetCurrencySymbol(c: Models.Currency) : string {
+    switch (c) {
+        case Models.Currency.USD: return "usd";
+        case Models.Currency.LTC: return "ltc";
+        case Models.Currency.BTC: return "btc";
+        default: throw new Error("Unsupported currency " + Models.Currency[c]);
+    }
+}
+
+class OkCoinSymbolProvider {
+    public symbol : string;
+    
+    constructor(pair: Models.CurrencyPair) {
+        this.symbol = GetCurrencySymbol(pair.base) + "_" + GetCurrencySymbol(pair.quote);
+    }
+}
+
 export class OkCoin extends Interfaces.CombinedGateway {
     constructor(config : Config.IConfigProvider) {
         var signer = new OkCoinMessageSigner(config);

--- a/src/service/gateways/okcoin.ts
+++ b/src/service/gateways/okcoin.ts
@@ -471,7 +471,8 @@ class OkCoinSymbolProvider {
 }
 
 export class OkCoin extends Interfaces.CombinedGateway {
-    constructor(config : Config.IConfigProvider) {
+    constructor(config : Config.IConfigProvider, pair: Models.CurrencyPair) {
+        var symbol = new OkCoinSymbolProvider(pair);
         var signer = new OkCoinMessageSigner(config);
         var http = new OkCoinHttp(config, signer);
         var socket = new OkCoinWebsocket(config);

--- a/src/service/interfaces.ts
+++ b/src/service/interfaces.ts
@@ -10,6 +10,7 @@ export interface IExchangeDetailsGateway {
     makeFee(): number;
     takeFee(): number;
     exchange(): Models.Exchange;
+    supportedCurrencyPairs: Models.CurrencyPair[];
 
     hasSelfTradePrevention: boolean;
 }
@@ -88,6 +89,7 @@ export interface IBroker extends IBrokerConnectivity {
     takeFee(): number;
     exchange(): Models.Exchange;
     pair: Models.CurrencyPair;
+    supportedCurrencyPairs: Models.CurrencyPair[];
 
     hasSelfTradePrevention: boolean;
 }

--- a/src/service/main.ts
+++ b/src/service/main.ts
@@ -133,9 +133,9 @@ var liveTradingSetup = () => {
     
     var getExch = (orderCache: Broker.OrderStateCache): Interfaces.CombinedGateway => {
         switch (exchange) {
-            case Models.Exchange.HitBtc: return <Interfaces.CombinedGateway>(new HitBtc.HitBtc(config));
-            case Models.Exchange.Coinbase: return <Interfaces.CombinedGateway>(new Coinbase.Coinbase(config, orderCache, timeProvider));
-            case Models.Exchange.OkCoin: return <Interfaces.CombinedGateway>(new OkCoin.OkCoin(config));
+            case Models.Exchange.HitBtc: return <Interfaces.CombinedGateway>(new HitBtc.HitBtc(config, pair));
+            case Models.Exchange.Coinbase: return <Interfaces.CombinedGateway>(new Coinbase.Coinbase(config, orderCache, timeProvider, pair));
+            case Models.Exchange.OkCoin: return <Interfaces.CombinedGateway>(new OkCoin.OkCoin(config, pair));
             case Models.Exchange.Null: return <Interfaces.CombinedGateway>(new NullGw.NullGateway());
             default: throw new Error("no gateway provided for exchange " + exchange);
         }

--- a/src/service/main.ts
+++ b/src/service/main.ts
@@ -61,7 +61,15 @@ var config = new Config.ConfigProvider();
 var mainLog = Utils.log("tribeca:main");
 var messagingLog = Utils.log("tribeca:messaging");
 
-var pair = new Models.CurrencyPair(Models.Currency.BTC, Models.Currency.USD);
+function ParseCurrencyPair(raw: string) : Models.CurrencyPair {
+    var split = raw.split("/");
+    if (split.length !== 2) 
+        throw new Error("Invalid currency pair! Must be in the format of BASE/QUOTE, eg BTC/USD");
+    
+    return new Models.CurrencyPair(Models.Currency[split[0]], Models.Currency[split[1]]);
+}
+var pair = ParseCurrencyPair(config.GetString("TradedPair"));
+
 var defaultActive : Models.SerializedQuotesActive = new Models.SerializedQuotesActive(false, moment.unix(1));
 var defaultQuotingParameters : Models.QuotingParameters = new Models.QuotingParameters(.3, .05, Models.QuotingMode.Top, 
     Models.FairValueModel.BBO, 3, .8, false, Models.AutoPositionMode.Off, false, 2.5, 300, .095, 2*.095, .095, 3, .1);
@@ -260,6 +268,9 @@ var runTradingSystem = (classes: SimulationClasses) : Q.Promise<boolean> => {
         var cancelOrderReceiver = getReceiver(Messaging.Topics.CancelOrder);
         
         var gateway = classes.getExch(orderCache);
+        
+        if (!_.some(gateway.base.supportedCurrencyPairs, p => p.base === pair.base && p.quote === pair.quote))
+            throw new Error("Unsupported currency pair!. Please check that gateway " + gateway.base.name() + " supports the value specified in TradedPair config value");
     
         var broker = new Broker.ExchangeBroker(pair, gateway.md, gateway.base, gateway.oe, gateway.pg, connectivity);
         var orderBroker = new Broker.OrderBroker(timeProvider, broker, gateway.oe, orderPersister, tradesPersister, orderStatusPublisher,


### PR DESCRIPTION
This pull request will make tribeca support currency pairs other than BTC/USD. This is configurable via the `TradedPair` configuration value. Upgraders must specify a value, or else an error will be thrown on start up.

I have elected to not expose LTC, DOGE, or any other currency in a pair which does not trade in $.01 increments, that will have to be a larger change in the future. There's a bunch of assumptions in the order generation logic and the UI preventing that change right now.