### PR TITLE
Quoting styles

### DIFF
--- a/src/service/quoting-styles/helpers.ts
+++ b/src/service/quoting-styles/helpers.ts
@@ -1,0 +1,12 @@
+/// <reference path="../../common/models.ts" />
+
+import Models = require("../../common/models");
+
+export class GeneratedQuote {
+    constructor(public bidPx: number, public bidSz: number, public askPx: number, public askSz: number) { }
+}
+
+export interface QuoteStyle {
+    Mode : Models.QuotingMode;
+    GenerateQuote(market: Models.Market, fv: Models.FairValue, params: Models.QuotingParameters) : GeneratedQuote;
+}

--- a/src/service/quoting-styles/mid-market.ts
+++ b/src/service/quoting-styles/mid-market.ts
@@ -1,0 +1,18 @@
+/// <reference path="../../common/models.ts" />
+
+import StyleHelpers = require("./helpers");
+import Models = require("../../common/models");
+
+export class MidMarketQuoteStyle implements StyleHelpers.QuoteStyle {
+    Mode = Models.QuotingMode.Mid;
+    
+    GenerateQuote = (market: Models.Market, fv: Models.FairValue, params: Models.QuotingParameters) : StyleHelpers.GeneratedQuote => {
+        var width = params.width;
+        var size = params.size;
+    
+        var bidPx = Math.max(fv.price - width, 0);
+        var askPx = fv.price + width;
+    
+        return new StyleHelpers.GeneratedQuote(bidPx, size, askPx, size);
+    };
+}

--- a/src/service/quoting-styles/style-registry.ts
+++ b/src/service/quoting-styles/style-registry.ts
@@ -5,6 +5,14 @@ import StyleHelpers = require("./helpers");
 import Models = require("../../common/models");
 import _ = require("lodash");
 
+class NullQuoteGenerator implements StyleHelpers.QuoteStyle {
+	Mode = null;
+    
+    GenerateQuote = (market: Models.Market, fv: Models.FairValue, params: Models.QuotingParameters) : StyleHelpers.GeneratedQuote => {
+		return null;
+	};
+}
+
 export class QuotingStyleRegistry {
 	private _mapping : StyleHelpers.QuoteStyle[];
 	
@@ -19,13 +27,5 @@ export class QuotingStyleRegistry {
 			return QuotingStyleRegistry.NullQuoteGenerator;
 			
 		return mod;
-	};
-}
-
-class NullQuoteGenerator implements StyleHelpers.QuoteStyle {
-	Mode = null;
-    
-    GenerateQuote = (market: Models.Market, fv: Models.FairValue, params: Models.QuotingParameters) : StyleHelpers.GeneratedQuote => {
-		return null;
 	};
 }

--- a/src/service/quoting-styles/style-registry.ts
+++ b/src/service/quoting-styles/style-registry.ts
@@ -1,0 +1,31 @@
+/// <reference path="../../common/models.ts" />
+/// <reference path="../../../typings/tsd.d.ts" />
+
+import StyleHelpers = require("./helpers");
+import Models = require("../../common/models");
+import _ = require("lodash");
+
+export class QuotingStyleRegistry {
+	private _mapping : StyleHelpers.QuoteStyle[];
+	
+	constructor(private _modules: StyleHelpers.QuoteStyle[]) {}
+	
+	private static NullQuoteGenerator : StyleHelpers.QuoteStyle = new NullQuoteGenerator();
+	
+	public Get = (mode : Models.QuotingMode) : StyleHelpers.QuoteStyle => {
+		var mod = this._modules[mode];
+		
+		if (typeof mod === "undefined")
+			return QuotingStyleRegistry.NullQuoteGenerator;
+			
+		return mod;
+	};
+}
+
+class NullQuoteGenerator implements StyleHelpers.QuoteStyle {
+	Mode = null;
+    
+    GenerateQuote = (market: Models.Market, fv: Models.FairValue, params: Models.QuotingParameters) : StyleHelpers.GeneratedQuote => {
+		return null;
+	};
+}

--- a/src/service/quoting-styles/style-registry.ts
+++ b/src/service/quoting-styles/style-registry.ts
@@ -16,12 +16,14 @@ class NullQuoteGenerator implements StyleHelpers.QuoteStyle {
 export class QuotingStyleRegistry {
 	private _mapping : StyleHelpers.QuoteStyle[];
 	
-	constructor(private _modules: StyleHelpers.QuoteStyle[]) {}
+	constructor(modules: StyleHelpers.QuoteStyle[]) {
+		this._mapping = _.sortBy(modules, s => s.Mode);
+	}
 	
 	private static NullQuoteGenerator : StyleHelpers.QuoteStyle = new NullQuoteGenerator();
 	
 	public Get = (mode : Models.QuotingMode) : StyleHelpers.QuoteStyle => {
-		var mod = this._modules[mode];
+		var mod = this._mapping[mode];
 		
 		if (typeof mod === "undefined")
 			return QuotingStyleRegistry.NullQuoteGenerator;

--- a/src/service/quoting-styles/top-join.ts
+++ b/src/service/quoting-styles/top-join.ts
@@ -1,0 +1,96 @@
+/// <reference path="../../common/models.ts" />
+
+import StyleHelpers = require("./helpers");
+import Models = require("../../common/models");
+
+export class TopOfTheMarketQuoteStyle implements StyleHelpers.QuoteStyle {
+    Mode = Models.QuotingMode.Top;
+    
+    GenerateQuote = (market: Models.Market, fv: Models.FairValue, params: Models.QuotingParameters) : StyleHelpers.GeneratedQuote => {
+        return computeTopJoinQuote(market, fv, params);
+    };
+}
+
+export class InverseTopOfTheMarketQuoteStyle implements StyleHelpers.QuoteStyle {
+    Mode = Models.QuotingMode.InverseTop;
+    
+    GenerateQuote = (market: Models.Market, fv: Models.FairValue, params: Models.QuotingParameters) : StyleHelpers.GeneratedQuote => {
+        return computeInverseJoinQuote(market, fv, params);
+    };
+}
+
+export class InverseJoinQuoteStyle implements StyleHelpers.QuoteStyle {
+    Mode = Models.QuotingMode.InverseJoin;
+    
+    GenerateQuote = (market: Models.Market, fv: Models.FairValue, params: Models.QuotingParameters) : StyleHelpers.GeneratedQuote => {
+        return computeInverseJoinQuote(market, fv, params);
+    };
+}
+
+export class JoinQuoteStyle implements StyleHelpers.QuoteStyle {
+    Mode = Models.QuotingMode.Join;
+    
+    GenerateQuote = (market: Models.Market, fv: Models.FairValue, params: Models.QuotingParameters) : StyleHelpers.GeneratedQuote => {
+        return computeTopJoinQuote(market, fv, params);
+    };
+}
+
+function getQuoteAtTopOfMarket(filteredMkt: Models.Market, params: Models.QuotingParameters): StyleHelpers.GeneratedQuote {
+    var topBid = (filteredMkt.bids[0].size > params.stepOverSize ? filteredMkt.bids[0] : filteredMkt.bids[1]);
+    if (typeof topBid === "undefined") topBid = filteredMkt.bids[0]; // only guaranteed top level exists
+    var bidPx = topBid.price;
+
+    var topAsk = (filteredMkt.asks[0].size > params.stepOverSize ? filteredMkt.asks[0] : filteredMkt.asks[1]);
+    if (typeof topAsk === "undefined") topAsk = filteredMkt.asks[0];
+    var askPx = topAsk.price;
+
+    return new StyleHelpers.GeneratedQuote(bidPx, topBid.size, askPx, topAsk.size);
+}
+
+function computeTopJoinQuote(filteredMkt: Models.Market, fv: Models.FairValue, params: Models.QuotingParameters) {
+    var genQt = getQuoteAtTopOfMarket(filteredMkt, params);
+
+    if (params.mode === Models.QuotingMode.Top && genQt.bidSz > .2) {
+        genQt.bidPx += .01;
+    }
+
+    var minBid = fv.price - params.width / 2.0;
+    genQt.bidPx = Math.min(minBid, genQt.bidPx);
+
+    if (params.mode === Models.QuotingMode.Top && genQt.askSz > .2) {
+        genQt.askPx -= .01;
+    }
+
+    var minAsk = fv.price + params.width / 2.0;
+    genQt.askPx = Math.max(minAsk, genQt.askPx);
+
+    genQt.bidSz = params.size;
+    genQt.askSz = params.size;
+
+    return genQt;
+}
+
+function computeInverseJoinQuote(filteredMkt: Models.Market, fv: Models.FairValue, params: Models.QuotingParameters) {
+    var genQt = getQuoteAtTopOfMarket(filteredMkt, params);
+
+    var mktWidth = Math.abs(genQt.askPx - genQt.bidPx);
+    if (mktWidth > params.width) {
+        genQt.askPx += params.width;
+        genQt.bidPx -= params.width;
+    }
+
+    if (params.mode === Models.QuotingMode.InverseTop) {
+        if (genQt.bidSz > .2) genQt.bidPx += .01;
+        if (genQt.askSz > .2) genQt.askPx -= .01;
+    }
+
+    if (mktWidth < (2.0 * params.width / 3.0)) {
+        genQt.askPx += params.width / 4.0;
+        genQt.bidPx -= params.width / 4.0;
+    }
+
+    genQt.bidSz = params.size;
+    genQt.askSz = params.size;
+
+    return genQt;
+}


### PR DESCRIPTION
This allows users to add customizable quoting modes. To add a custom quoting mode,

1) Create a class implementing `QuoteStyle` found in `src/service/quoting-styles/helpers.ts`. The interface gives you the current state of the market, the calculated fair value, and the current quoting parameters. As part of implementing the interface, you'll need to create a new enum member for `QuotingMode` in models.ts. Inside that class you can create any sort of logic logic to create a two-sided market, or return null to signify that there should be no quote in the market.
2) Install the new class alongside the provided list of modes in the `QuotingStyleRegistry` in `main.js`.
3) Rebuild and restart tribeca.