### PR TITLE
Added PingPong quoting mode.

### DIFF
--- a/src/common/models.ts
+++ b/src/common/models.ts
@@ -331,7 +331,7 @@ export function currencyPairEqual(a: CurrencyPair, b: CurrencyPair): boolean {
     return a.base === b.base && a.quote === b.quote;
 }
 
-export enum QuotingMode { Top, Mid, Join, InverseJoin, InverseTop }
+export enum QuotingMode { Top, Mid, Join, InverseJoin, InverseTop, PingPong }
 export enum FairValueModel { BBO, wBBO }
 export enum AutoPositionMode { Off, EwmaBasic }
 
@@ -382,6 +382,8 @@ export class TradeSafety {
     constructor(public buy: number,
                 public sell: number,
                 public combined: number,
+                public buyPing: number,
+                public sellPong: number,
                 public time: moment.Moment) {}
 }
 

--- a/src/service/main.ts
+++ b/src/service/main.ts
@@ -351,6 +351,7 @@ var runTradingSystem = (classes: SimulationClasses) : Q.Promise<boolean> => {
             new TopJoin.InverseTopOfTheMarketQuoteStyle(),
             new TopJoin.JoinQuoteStyle(),
             new TopJoin.TopOfTheMarketQuoteStyle(),
+            new TopJoin.PingPongQuoteStyle(),
         ]);
     
         var positionMgr = new PositionManagement.PositionManager(timeProvider, rfvPersister, fvEngine, initRfv, shortEwma, longEwma);

--- a/src/service/quoting-engine.ts
+++ b/src/service/quoting-engine.ts
@@ -118,6 +118,13 @@ export class QuotingEngine {
             return null;
         }
         
+        if (params.mode === Models.QuotingMode.PingPong) {
+          if (safety.buyPing && unrounded.askPx < safety.buyPing + params.width)
+            unrounded.askPx = safety.buyPing + params.width;
+          if (safety.sellPong && unrounded.bidPx > safety.sellPong - params.width)
+            unrounded.bidPx = safety.sellPong - params.width;
+        }
+        
         if (safety.sell > params.tradesPerMinute) {
             unrounded.askPx = null;
             unrounded.askSz = null;

--- a/src/service/quoting-styles/top-join.ts
+++ b/src/service/quoting-styles/top-join.ts
@@ -27,6 +27,14 @@ export class InverseJoinQuoteStyle implements StyleHelpers.QuoteStyle {
     };
 }
 
+export class PingPongQuoteStyle implements StyleHelpers.QuoteStyle {
+    Mode = Models.QuotingMode.PingPong;
+
+    GenerateQuote = (market: Models.Market, fv: Models.FairValue, params: Models.QuotingParameters) : StyleHelpers.GeneratedQuote => {
+        return computePingPongQuote(market, fv, params);
+    };
+}
+
 export class JoinQuoteStyle implements StyleHelpers.QuoteStyle {
     Mode = Models.QuotingMode.Join;
     
@@ -88,6 +96,30 @@ function computeInverseJoinQuote(filteredMkt: Models.Market, fv: Models.FairValu
         genQt.askPx += params.width / 4.0;
         genQt.bidPx -= params.width / 4.0;
     }
+
+    genQt.bidSz = params.size;
+    genQt.askSz = params.size;
+
+    return genQt;
+}
+
+//computePingPongQuote is same as computeTopJoinQuote but need to use params.mode === Models.QuotingMode.PingPong 
+function computePingPongQuote(filteredMkt: Models.Market, fv: Models.FairValue, params: Models.QuotingParameters) {
+    var genQt = getQuoteAtTopOfMarket(filteredMkt, params);
+
+    if (params.mode === Models.QuotingMode.PingPong && genQt.bidSz > .2) {
+        genQt.bidPx += .01;
+    }
+
+    var minBid = fv.price - params.width / 2.0;
+    genQt.bidPx = Math.min(minBid, genQt.bidPx);
+
+    if (params.mode === Models.QuotingMode.PingPong && genQt.askSz > .2) {
+        genQt.askPx -= .01;
+    }
+
+    var minAsk = fv.price + params.width / 2.0;
+    genQt.askPx = Math.max(minAsk, genQt.askPx);
 
     genQt.bidSz = params.size;
     genQt.askSz = params.size;


### PR DESCRIPTION
At the wiki you may want to add (note that english is not my mother language):
  * `PingPong` - Same as `Join`, but never violate the calculated `width` from the last sold or bought `size`.

This PR adds a new quoting mode named `PingPong` that runs equal than `Join`, but if `Join` is going to create a quote with a margin *too low*, it re-calculates the price of the next quote. To do this it loops `onTrade` over the last trades to collect the price of the last `size` to make sure that at least the quote is created with a margin equal to the `width`. The relevant values are saved in `TradeSafety` as `buyPing` and `sellPong` variables ready for use whenever a quote is calculated.

It may not have the frequency of other quoting modes, but is yet-another respectable trading strategy.

In my local i have displayed the buyPing and sellPong values in a ugly template that i didn't added to this PR because this values may be OK to be just internal (also to avoid having useless elements in the GUI for the general public, anyway the prices of the current quote are always visible). Therefore this PR doesn't contain any visual modification in the GUI, but i can add it if you wish.