### PR TITLE
Fixed Cannot read property 'toString' of null at CoinbaseOrderEntryGateway.sendOrder.

### DIFF
--- a/src/service/quoting-engine.ts
+++ b/src/service/quoting-engine.ts
@@ -119,9 +119,9 @@ export class QuotingEngine {
         }
         
         if (params.mode === Models.QuotingMode.PingPong) {
-          if (safety.buyPing && unrounded.askPx < safety.buyPing + params.width)
+          if (unrounded.askSz && safety.buyPing && unrounded.askPx < safety.buyPing + params.width)
             unrounded.askPx = safety.buyPing + params.width;
-          if (safety.sellPong && unrounded.bidPx > safety.sellPong - params.width)
+          if (unrounded.bidSz && safety.sellPong && unrounded.bidPx > safety.sellPong - params.width)
             unrounded.bidPx = safety.sellPong - params.width;
         }
         


### PR DESCRIPTION
sorry found a bug at startup IF `tbp` and `pDiv` have too small values, THEN the calculated quote have 0 `size`. Thats OK, but is not ok to calculate the `price` of empty orders and try to send them.

Now while avoiding to calculate the price, corrupted orders are not send anymore.