### PR TITLE
New Coinbase API now includes ETH positions in getAccounts().

### DIFF
--- a/src/common/models.ts
+++ b/src/common/models.ts
@@ -58,7 +58,7 @@ export class MarketTrade implements ITimestamped {
 }
 
 export enum GatewayType { MarketData, OrderEntry, Position }
-export enum Currency { USD, BTC, LTC, EUR, GBP, CNY }
+export enum Currency { USD, BTC, LTC, EUR, GBP, CNY , ETH }
 export enum ConnectivityStatus { Connected, Disconnected }
 export enum Exchange { Null, HitBtc, OkCoin, AtlasAts, BtcChina, Coinbase, Bitfinex }
 export enum Side { Bid, Ask, Unknown }

--- a/src/service/gateways/coinbase.ts
+++ b/src/service/gateways/coinbase.ts
@@ -796,6 +796,7 @@ function GetCurrencyEnum(name: string): Models.Currency {
         case "USD": return Models.Currency.USD;
         case "EUR": return Models.Currency.EUR;
         case "GBP": return Models.Currency.GBP;
+        case "ETH": return Models.Currency.ETH;
         default: throw new Error("Unsupported currency " + name);
     }
 }
@@ -806,6 +807,7 @@ function GetCurrencySymbol(c: Models.Currency): string {
         case Models.Currency.GBP: return "GBP";
         case Models.Currency.BTC: return "BTC";
         case Models.Currency.EUR: return "EUR";
+        case Models.Currency.ETH: return "ETH";
         default: throw new Error("Unsupported currency " + Models.Currency[c]);
     }
 }


### PR DESCRIPTION
This PR fixes an exception while downloading Coinbase positions (Unsupported currency ETH).

It occurs since midnight 25th of May 2016 because Coinbase added ETH currency to the response of getAccounts() but GetCurrencyEnum() throw expections at unkown currencies.

Hope this fix is ok; it works for me apparently without problems.