### PR TITLE
Updated Coinbase API URLs to GDAX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,9 @@ ENV HitBtcApiKey NULL
 ENV HitBtcSecret NULL
 ENV HitBtcOrderDestination HitBtc
 ## Coinbase
-ENV CoinbaseRestUrl https://api-public.sandbox.exchange.coinbase.com
-ENV CoinbaseWebsocketUrl https://ws-feed-public.sandbox.exchange.coinbase.com
+## Use GDAX keys
+ENV CoinbaseRestUrl https://api-public.sandbox.gdax.com
+ENV CoinbaseWebsocketUrl wss://ws-feed-public.sandbox.gdax.com
 ENV CoinbasePassphrase NULL
 ENV CoinbaseApiKey NULL
 ENV CoinbaseSecret NULL
@@ -59,8 +60,8 @@ ENV BitfinexOrderDestination Bitfinex
 #ENV HitBtcMarketDataUrl ws://api.hitbtc.com:80
 #ENV HitBtcSocketIoUrl https://api.hitbtc.com:8081
 ## Coinbase
-#ENV CoinbaseRestUrl https://api.exchange.coinbase.com
-#ENV CoinbaseWebsocketUrl wss://ws-feed.exchange.coinbase.com
+#ENV CoinbaseRestUrl https://api.gdax.com
+#ENV CoinbaseWebsocketUrl wss://ws-feed.gdax.com
 
 WORKDIR tribeca/service
 CMD ["forever", "main.js"]

--- a/sample-dev-tribeca.json
+++ b/sample-dev-tribeca.json
@@ -15,8 +15,8 @@
     "HitBtcSecret": "NULL",
     "HitBtcOrderDestination": "HitBtc",
     
-    "CoinbaseRestUrl": "https://api-public.sandbox.exchange.coinbase.com",
-    "CoinbaseWebsocketUrl": "https://ws-feed-public.sandbox.exchange.coinbase.com",
+    "CoinbaseRestUrl": "https://api-public.sandbox.gdax.com",
+    "CoinbaseWebsocketUrl": "wss://ws-feed-public.sandbox.gdax.com",
     "CoinbasePassphrase": "NULL",
     "CoinbaseApiKey": "NULL",
     "CoinbaseSecret": "NULL",

--- a/sample-prod-tribeca.json
+++ b/sample-prod-tribeca.json
@@ -15,8 +15,8 @@
     "HitBtcSecret": "NULL",
     "HitBtcOrderDestination": "HitBtc",
     
-    "CoinbaseRestUrl": "https://api.exchange.coinbase.com",
-    "CoinbaseWebsocketUrl": "https://ws-feed-public.sandbox.exchange.coinbase.com",
+    "CoinbaseRestUrl": "https://api.gdax.com",
+    "CoinbaseWebsocketUrl": "wss://ws-feed.gdax.com",
     "CoinbasePassphrase": "NULL",
     "CoinbaseApiKey": "NULL",
     "CoinbaseSecret": "NULL",


### PR DESCRIPTION
Coinbase Exchange changed its name to GDAX three weeks ago, and using the new
GDAX URLs and API keys was the only way I could get it to connect.