### PR TITLE
Add spread to UI

### DIFF
--- a/src/admin/market-quoting.ts
+++ b/src/admin/market-quoting.ts
@@ -24,6 +24,7 @@ interface MarketQuotingScope extends ng.IScope {
     qBidSz: number;
     qBidPx: string;
     fairValue: string;
+    spreadValue: string;
     qAskPx: string;
     qAskSz: number;
     extVal: string;
@@ -38,6 +39,7 @@ var MarketQuotingController = ($scope: MarketQuotingScope,
         product: Shared.ProductState) => {
 
     var toPrice = (px: number) : string => px.toFixed(product.fixed);
+    var toPercent = (askPx: number, bidPx: number): string => ((askPx - bidPx) / askPx * 100).toFixed(2);
 
     var clearMarket = () => {
         $scope.levels = [];
@@ -54,9 +56,14 @@ var MarketQuotingController = ($scope: MarketQuotingScope,
         $scope.qAskSz = null;
     };
 
+    var clearSpread = () => {
+        $scope.spreadValue = null;
+    }
+
     var clearQuote = () => {
         clearBid();
         clearAsk();
+        clearSpread();
     };
 
     var clearFairValue = () => {
@@ -111,6 +118,15 @@ var MarketQuotingController = ($scope: MarketQuotingScope,
             }
             else {
                 clearAsk();
+            }
+
+            if (quote.ask !== null && quote.bid !== null) {
+                const spreadAbsolutePrice = (quote.ask.price - quote.bid.price).toFixed(2);
+                const spreadPercent = toPercent(quote.ask.price, quote.bid.price);
+                $scope.spreadValue = `${spreadAbsolutePrice} / ${spreadPercent}%`;
+            }
+            else {
+                clearFairValue();
             }
         }
         else {

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -5,9 +5,9 @@
     <link rel="stylesheet" href="/css/bootstrap.min.css">
     <link rel="stylesheet" href="/css/bootstrap-theme.min.css">
     <link rel="stylesheet" href="/css/ui-grid.min.css">
-    
+
     <script src="/js/admin/bundle.min.js"></script>
-    
+
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 
     <title>tribeca [{{ env }}]</title>
@@ -20,7 +20,7 @@
 
         .black { color: black }
         .red { color: red }
-        
+
         .row {
             margin-left: 0;
             margin-right: 0
@@ -41,6 +41,7 @@
             <th>bidSz</th>
             <th>bidPx</th>
             <th>FV</th>
+            <th>Spread</th>
             <th>askPx</th>
             <th>askSz</th>
         </tr>
@@ -49,6 +50,7 @@
             <td ng-class="bidIsLive ? 'text-danger' : 'text-muted'">{{ qBidSz|number:2 }}</td>
             <td ng-class="bidIsLive ? 'text-danger' : 'text-muted'">{{ qBidPx }}</td>
             <td>{{ fairValue }}</td>
+            <td>{{ spreadValue }}</td>
             <td ng-class="askIsLive ? 'text-danger' : 'text-muted'">{{ qAskPx }}</td>
             <td ng-class="askIsLive ? 'text-danger' : 'text-muted'">{{ qAskSz|number:2 }}</td>
         </tr>
@@ -56,6 +58,7 @@
             <td>mkt{{ $index }}</td>
             <td>{{ level.bidSize|number:2 }}</td>
             <td ng-class="level.bidClass">{{ level.bidPrice }}</td>
+            <td></td>
             <td></td>
             <td ng-class="level.askClass">{{ level.askPrice }}</td>
             <td>{{ level.askSize|number:2 }}</td>
@@ -155,7 +158,7 @@
                             </div>
 
                             <h4 style="font-size: 20px" class="col-md-12 col-xs-3">{{ exch_name }}</h4>
-                            
+
                             <position-grid></position-grid>
                         </div>
                     </div>
@@ -266,23 +269,23 @@
                                                 ng-model="pair.quotingParameters.display.tradeRateSeconds">
                                         </td>
                                         <td>
-                                            <input class="btn btn-default btn col-md-1 col-xs-6" 
+                                            <input class="btn btn-default btn col-md-1 col-xs-6"
                                                 style="width:55px"
-                                                type="button" 
-                                                ng-click="pair.quotingParameters.reset()" 
+                                                type="button"
+                                                ng-click="pair.quotingParameters.reset()"
                                                 value="Reset" />
                                         </td>
                                         <td>
                                             <input class="btn btn-default btn col-md-1 col-xs-6"
-                                                style="width:50px" 
-                                                type="submit" 
-                                                ng-click="pair.quotingParameters.submit()" 
+                                                style="width:50px"
+                                                type="submit"
+                                                ng-click="pair.quotingParameters.submit()"
                                                 ng-disabled="!pair.quotingParameters.connected"
                                                 value="Save" />
                                         </td>
                                     </tr>
                                 </tbody>
-                                
+
                             </table>
                         </div>
 


### PR DESCRIPTION
@michaelgrosner This PR addresses #128 for displaying the spread in the UI.

We calculate both the absolute and percent spread in the market-quoting class and display it in the form:

`Absolute / Percent`

Here is what it looks like:

![image](https://cloud.githubusercontent.com/assets/4533277/26756059/812fa948-4868-11e7-93b4-07377eab26b9.png)

Question:

Instead of creating an entire column for the spread, do you think we could add the spread in the FV column as well?

Todo:

Include documentation on the spread in the [wiki](https://github.com/michaelgrosner/tribeca/wiki#how-do-i-see-whats-going-on)