### PR TITLE
Docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.docs
+test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,8 @@
 FROM node:7.9
-RUN apt-get update
 
-RUN apt-get install -y git
+WORKDIR /tribeca
 
-RUN git clone https://github.com/michaelgrosner/tribeca.git
-
-WORKDIR tribeca
-
-# Chose the branch you want to build. Leave as it is if you want to build the master branch (recommanded).
-# RUN git checkout -B YOUR-NAME-OF-THE-BRANCH --track remotes/origin/NAME-OF-THE-BRANCH-IN-GITHUB
+COPY . /tribeca
 
 RUN npm install -g grunt-cli forever
 RUN npm install
@@ -16,54 +10,6 @@ RUN grunt compile
 
 EXPOSE 3000 5000
 
-# General config properties. Properties with `NULL` should be replaced with your own exchange account information.
-ENV TRIBECA_MODE dev
-ENV EXCHANGE null
-ENV TradedPair BTC/USD
-ENV WebClientUsername NULL
-ENV WebClientPassword NULL
-ENV WebClientListenPort 3000
-# IP to access mongo instance. If you are on a mac, run `boot2docker ip` and replace `tribeca-mongo`.
-ENV MongoDbUrl mongodb://tribeca-mongo:27017/tribeca
-
-# DEV
-## HitBtc
-ENV HitBtcPullUrl http://demo-api.hitbtc.com
-ENV HitBtcOrderEntryUrl ws://demo-api.hitbtc.com:8080
-ENV HitBtcMarketDataUrl ws://demo-api.hitbtc.com:80
-ENV HitBtcSocketIoUrl https://demo-api.hitbtc.com:8081
-ENV HitBtcApiKey NULL
-ENV HitBtcSecret NULL
-ENV HitBtcOrderDestination HitBtc
-## Coinbase
-## Use GDAX keys
-ENV CoinbaseRestUrl https://api-public.sandbox.gdax.com
-ENV CoinbaseWebsocketUrl wss://ws-feed-public.sandbox.gdax.com
-ENV CoinbasePassphrase NULL
-ENV CoinbaseApiKey NULL
-ENV CoinbaseSecret NULL
-ENV CoinbaseOrderDestination Coinbase
-## OkCoin
-ENV OkCoinWsUrl wss://real.okcoin.com:10440/websocket/okcoinapi
-ENV OkCoinHttpUrl https://www.okcoin.com/api/v1/
-ENV OkCoinApiKey NULL
-ENV OkCoinSecretKey NULL
-ENV OkCoinOrderDestination OkCoin
-## Bitfinex
-ENV BitfinexHttpUrl https://api.bitfinex.com/v1
-ENV BitfinexKey NULL
-ENV BitfinexSecret NULL
-ENV BitfinexOrderDestination Bitfinex
-
-# PROD - values provided for reference.
-## HitBtc
-#ENV HitBtcPullUrl http://api.hitbtc.com
-#ENV HitBtcOrderEntryUrl wss://api.hitbtc.com:8080
-#ENV HitBtcMarketDataUrl ws://api.hitbtc.com:80
-#ENV HitBtcSocketIoUrl https://api.hitbtc.com:8081
-## Coinbase
-#ENV CoinbaseRestUrl https://api.gdax.com
-#ENV CoinbaseWebsocketUrl wss://ws-feed.gdax.com
-
 WORKDIR tribeca/service
+
 CMD ["forever", "main.js"]

--- a/README.md
+++ b/README.md
@@ -8,17 +8,25 @@
 
 Runs on the latest node.js (v7.8 or greater). Persistence is acheived using mongodb. Installation is recommended via Docker, but manual installation is also supported.
 
+### Docker compose installation
+
+1. Install [docker compose](https://docs.docker.com/compose/install/).
+
+2. Change the environment variables of `env` file to match your desired [configuration](https://github.com/michaelgrosner/tribeca#configuration). Input your exchange connectivity information, account information, and mongoDB credentials.
+
+3. Run `docker-compose up -d --build`. If you run `docker-compose ps`, you should see the containers running.
+
 ### Docker Installation
 
 1. Please install [docker](https://www.docker.com/) for your system before preceeding. Requires at least Docker 1.7.1. Mac/Windows only: Ensure boot2docker or docker-machine is set up, depending on Docker version. See [the docs](https://docs.docker.com/installation/mac/) for more help.
 
 2. Set up mongodb. If you do not have a mongodb instance already running: `docker run -p 27017:27017 --name tribeca-mongo -d mongo`.
 
-3. Copy the repository [Dockerfile](https://raw.githubusercontent.com/michaelgrosner/tribeca/master/Dockerfile) into a text editor. Change the environment variables to match your desired [configuration](https://github.com/michaelgrosner/tribeca#configuration). Input your exchange connectivity information, account information, and mongoDB credentials.
+2. Change the environment variables of `env` file to match your desired [configuration](https://github.com/michaelgrosner/tribeca#configuration). Input your exchange connectivity information, account information, and mongoDB credentials.
 
 4. Save the Dockerfile, preferably in a secure location and in an empty directory. Build the image from the Dockerfile `docker build -t tribeca .`
 
-5. Run the container `docker run -p 3000:3000 --link tribeca-mongo:mongo --name tribeca -d tribeca`. If you run `docker ps`, you should see tribeca and mongo containers running.
+5. Run the container `docker run -p 3000:3000 --link tribeca-mongo:mongo --env-file ./env --name tribeca -d tribeca`. If you run `docker ps`, you should see tribeca and mongo containers running.
 
 ### Manual Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+  tribeca:
+    build:
+      context: ./
+    image: tribeca
+    env_file:
+      - ./env
+    links:
+      - tribeca-mongo
+    ports:
+      - "3000:3000"
+    tty: true
+  tribeca-mongo:
+    image: mongo

--- a/env
+++ b/env
@@ -1,0 +1,49 @@
+# General config properties. Properties with `NULL` should be replaced with your own exchange account information.
+TRIBECA_MODE=dev
+EXCHANGE=null
+TradedPair=BTC/USD
+WebClientUsername=NULL
+WebClientPassword=NULL
+WebClientListenPort=3000
+MongoDbUrl=mongodb://tribeca-mongo:27017/tribeca
+
+NullGatewayTick=100
+
+# DEV
+## HitBtc
+HitBtcPullUrl=http://demo-api.hitbtc.com
+HitBtcOrderEntryUrl=ws://demo-api.hitbtc.com:8080
+HitBtcMarketDataUrl=ws://demo-api.hitbtc.com:80
+HitBtcSocketIoUrl=https://demo-api.hitbtc.com:8081
+HitBtcApiKey=NULL
+HitBtcSecret=NULL
+HitBtcOrderDestination=HitBtc
+## Coinbase
+## Use GDAX keys
+CoinbaseRestUrl=https://api-public.sandbox.gdax.com
+CoinbaseWebsocketUrl=wss://ws-feed-public.sandbox.gdax.com
+CoinbasePassphrase=NULL
+CoinbaseApiKey=NULL
+CoinbaseSecret=NULL
+CoinbaseOrderDestination=Coinbase
+## OkCoin
+OkCoinWsUrl=wss://real.okcoin.com:10440/websocket/okcoinapi
+OkCoinHttpUrl=https://www.okcoin.com/api/v1/
+OkCoinApiKey=NULL
+OkCoinSecretKey=NULL
+OkCoinOrderDestination=OkCoin
+## Bitfinex
+BitfinexHttpUrl=https://api.bitfinex.com/v1
+BitfinexKey=NULL
+BitfinexSecret=NULL
+BitfinexOrderDestination=Bitfinex
+
+# PROD - values provided for reference.
+## HitBtc
+#HitBtcPullUrl=http://api.hitbtc.com
+#HitBtcOrderEntryUrl=wss://api.hitbtc.com:8080
+#HitBtcMarketDataUrl=ws://api.hitbtc.com:80
+#HitBtcSocketIoUrl=https://api.hitbtc.com:8081
+## Coinbase
+#CoinbaseRestUrl=https://api.gdax.com
+#CoinbaseWebsocketUrl=wss://ws-feed.gdax.com


### PR DESCRIPTION
Adding `docker-compose` to tribeca. 

Since it already has Dockerfile, the docker-compose allows a more easier installation and a more "docker way" use. 

It would work better with docker versioning using tags, but if you think this is a good contribution, we can evolute this in one second step.