### PR TITLE
Remove requirement node-inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "lodash": "4.17.4",
     "moment": "2.18.1",
     "mongodb": "2.2.25",
-    "node-inspector": "^1.1.1",
     "node-uuid": "1.4.8",
     "q": "1.5.0",
     "request": "2.81.0",


### PR DESCRIPTION
Node-inspector is deprecated as functionality is built-in to node itself now. Keeping the dependency causes many problems similar to #157 for node-inspector and v8-debug packages. After removing node-inspector, it is possible to install and run tribeca fully functionally on node-js carbon and npm 5.5.1, which was not possible before.

edit: confirmed on multiple oses with clean installation, removed OS detail.