### PR TITLE
GDAX received market order message has size field

### DIFF
--- a/src/service/gateways/coinbase.ts
+++ b/src/service/gateways/coinbase.ts
@@ -45,6 +45,7 @@ interface CoinbaseReceived extends CoinbaseBase {
     order_id: string; // guid
     size: string; // "0.00"
     price: string; // "0.00"
+    order_type: string;
 }
 
 // The order is now open on the order book. This message will only be sent for orders which are not fully filled
@@ -231,6 +232,10 @@ class CoinbaseOrderBook {
     };
 
     public onReceived = (msg: CoinbaseReceived, t: Date): boolean => {
+        if(msg.order_type == 'market'){
+            return;
+        }
+        
         var price = convertPrice(msg.price);
         var size = convertSize(msg.size);
         var side = convertSide(msg);


### PR DESCRIPTION
This is an issue I found when received messages arrived for market orders from GDAX. The GDAX API documentation does not say that received messages for market orders have a size field. It only shows a size field for received messages for limit orders, but I've noticed that they in fact do have a size field. This is screwing up the order book calculation as a market order starts removing price levels in the onReceived method. It looks to me like the onReceived method is only meant to remove price levels for limit orders that cross the spread. the onMatch method takes care of removing price levels for market orders. The change I proposed fixed the issue on my part. Before the change, the GDAX order book from tribeca was not matching what I saw in the gdax web client. Some price levels near the BBO were missing in tribeca and there were instances where the size near the BBO went negative. After the change the tribeca order book matched the GDAX web client's order book and sizes were no longer going negative.