### PR TITLE
Add BCH to known currency list

### DIFF
--- a/src/common/models.ts
+++ b/src/common/models.ts
@@ -88,7 +88,8 @@ export enum Currency {
     WAVES, 
     BTU, 
     MAID, 
-    AMP 
+    AMP,
+    BCH
 }
 
 export function toCurrency(c: string) : Currency|undefined {


### PR DESCRIPTION
BCH was not supported. Adding it to models enabled support.